### PR TITLE
 Change title to "TypoScript Templates in 45 Minutes"

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -3,9 +3,9 @@
 
 .. _start:
 
-========================
-TypoScript in 45 Minutes
-========================
+==================================
+TypoScript Templates in 45 Minutes
+==================================
 
 :Previous Key:
       doc_tut_ts45

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -22,7 +22,7 @@
 ; endless list of all of the general simple settings
 ; you can use in 'conf.py'
 
-project     = TypoScript in 45 Minutes
+project     = TypoScript Templates in 45 Minutes
 version     = master (10-dev)
 release     = master (10-dev)
 t3author    = Documentation Team


### PR DESCRIPTION
The term "Typoscript" is currently used for the TypoScript syntax
and for TypoScript templating.

We now use "TypoScript Template" when referring to TypoScript templates.

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/77
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/120