### PR TITLE
fix typo

### DIFF
--- a/Documentation/HtmlTemplate/Index.rst
+++ b/Documentation/HtmlTemplate/Index.rst
@@ -45,7 +45,7 @@ For example to render a template with the menu we defined add:
 .. code-block:: html
 
    <nav>
-      <f:cObject typoscriptObjectPath="lib.textMenu" />
+      <f:cObject typoscriptObjectPath="lib.textmenu" />
    </nav>
 
    <div class="container">


### PR DESCRIPTION
In the previous page (https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/CreateAMenu/Index.html), the menu variable is all lower case (`lib.textmenu`). 

If you use the code like it was, this error gets thrown: 
> #1540246570: No Content Object definition found at TypoScript object path "lib.textMenu" 