### PR TITLE
[TASK] Mark TYPO3 Wiki as retired

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -22,7 +22,7 @@ Credits
 =======
 
 This manual was originally created in German by members of the TYPO3 CMS
-community in the TYPO3 wiki and then translated and corrected by
+community in the retired TYPO3 Wiki and then translated and corrected by
 more community members. Big thanks go the TYPO3 CMS community members for their
 initial efforts.
 


### PR DESCRIPTION
See https://github.com/TYPO3-Documentation/T3DocTeam/issues/170 for details.

Releases: main, 11.5, 10.4, 9.5, 8.7, 7.6